### PR TITLE
instruction-addrs: tweak dune files to support Nix and clean up endian handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ To build and run this you will need:
 * protoc
 * The following OPAM packages:
 	* ocaml-protoc-plugin
-	* hexstring
 	* base64
 
 To massively simplify this, simply run ```scripts/build-all.sh``` in your preferred install directory. This script assumes a completely fresh Ubuntu 20.04.5 installation. It is advised to run this script within a fresh VM but it should work on established installations. A complete installation can take several hours and will prompt for the sudo password at least once.

--- a/bin/dune
+++ b/bin/dune
@@ -2,13 +2,6 @@
  (public_name gtirb_semantics)
  (name main)
  (modules main)
- (libraries gtirb_semantics base64 yojson asli.libASL  llvm_disas)
-  (flags     :standard -cclib (:include llvmconf.sexp))
-  )
-
-(rule 
-  (targets llvmconf.sexp)
- (action (bash "$(opam var conf-llvm:config) --libs >> llvmconf.sexp"))
-  )
-
+ (libraries gtirb_semantics base64 yojson asli.libASL llvm_disas)
+)
 

--- a/bin/dune
+++ b/bin/dune
@@ -3,6 +3,6 @@
  (name main)
  (modules main)
  (libraries gtirb_semantics base64 yojson asli.libASL llvm_disas)
- (flags     :standard -cclib (:include ../llvm-disas/llvmconf.sexp))
+ (flags     :standard (:include ../llvm-disas/llvmconf.sexp))
 )
 

--- a/bin/dune
+++ b/bin/dune
@@ -3,5 +3,6 @@
  (name main)
  (modules main)
  (libraries gtirb_semantics base64 yojson asli.libASL llvm_disas)
+ (flags     :standard -cclib (:include ../llvm-disas/llvmconf.sexp))
 )
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -265,7 +265,7 @@ let () =
         )
         )) 
       )) l)) with_asts) in
-      (* List.iter (fun f -> Yojson.Safe.pretty_to_channel stdout f) paired; *)
+      List.iter (fun f -> Yojson.Safe.pretty_to_channel stderr f) paired; 
       map (Yojson.Safe.to_string) paired
   in 
 

--- a/dune-project
+++ b/dune-project
@@ -19,7 +19,7 @@
  (name gtirb_semantics)
  (synopsis "Add semantic information to the IR of a disassembled ARM64 binary")
  (description "A longer description")
- (depends ocaml dune Yojson asli ocaml-protoc-plugin hexstring base64 ctypes ctypes-foreign conf-llvm) 
+ (depends ocaml dune yojson asli ocaml-protoc-plugin hexstring base64 ctypes ctypes-foreign conf-llvm)
  (tags
   (decompilers instruction-lifters static-analysis)))
 

--- a/dune-project
+++ b/dune-project
@@ -19,7 +19,7 @@
  (name gtirb_semantics)
  (synopsis "Add semantic information to the IR of a disassembled ARM64 binary")
  (description "A longer description")
- (depends ocaml dune yojson asli ocaml-protoc-plugin hexstring base64 ctypes ctypes-foreign conf-llvm)
+ (depends ocaml dune yojson asli ocaml-protoc-plugin base64 ctypes ctypes-foreign conf-llvm)
  (tags
   (decompilers instruction-lifters static-analysis)))
 

--- a/gtirb_semantics.opam
+++ b/gtirb_semantics.opam
@@ -15,7 +15,6 @@ depends: [
   "yojson"
   "asli"
   "ocaml-protoc-plugin"
-  "hexstring"
   "base64"
   "ctypes"
   "ctypes-foreign"

--- a/gtirb_semantics.opam
+++ b/gtirb_semantics.opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/UQ-PAC/gtirb-semantics/issues"
 depends: [
   "ocaml"
   "dune" {>= "3.6"}
-  "Yojson"
+  "yojson"
   "asli"
   "ocaml-protoc-plugin"
   "hexstring"

--- a/lib/dune
+++ b/lib/dune
@@ -1,6 +1,6 @@
 (library
  (name gtirb_semantics)
- (libraries ocaml-protoc-plugin asli.libASL hexstring base64))
+ (libraries ocaml-protoc-plugin asli.libASL base64))
 
 (rule
  (targets AuxData.ml ByteInterval.ml CFG.ml CodeBlock.ml DataBlock.ml IR.ml Module.ml Offset.ml ProxyBlock.ml Section.ml Symbol.ml SymbolicExpression.ml)

--- a/llvm-disas/dune
+++ b/llvm-disas/dune
@@ -2,11 +2,12 @@
 (library
  (name llvm_disas)
  
- (libraries ctypes ctypes-foreign)
- (flags     :standard -cclib (:include llvmconf.sexp))
- )
+ (libraries ctypes ctypes.foreign)
+ (library_flags :standard -cclib (:include llvmconf.sexp))
+)
 
 (rule 
-  (targets llvmconf.sexp)
- (action (bash "$(opam var conf-llvm:config) --libs >> llvmconf.sexp"))
-  )
+ (targets llvmconf.sexp)
+ (action (bash "$(opam var conf-llvm:config) --libs > llvmconf.sexp"))
+)
+

--- a/llvm-disas/dune
+++ b/llvm-disas/dune
@@ -8,6 +8,7 @@
 
 (rule 
  (targets llvmconf.sexp)
- (action (bash "$(opam var conf-llvm:config) --libs > llvmconf.sexp"))
+ ; use opam if present otherwise fall back to $LLVM_CONFIG
+ (action (bash "if command -v opam; then llvm_config=$(opam var conf-llvm:config); fi ; ${llvm_config:-$LLVM_CONFIG} --libs > llvmconf.sexp"))
 )
 

--- a/llvm-disas/dune
+++ b/llvm-disas/dune
@@ -3,12 +3,23 @@
  (name llvm_disas)
  
  (libraries ctypes ctypes.foreign)
- (library_flags :standard -cclib (:include llvmconf.sexp))
+ (library_flags :standard (:include llvmconf.sexp))
 )
 
+; use opam's detected llvm if present, otherwise fall back to 'llvm-config'
+(rule
+ (target llvmconf.pth)
+ (action (with-stdout-to %{target}
+  (bash "if command -v opam &>/dev/null ; then opam var conf-llvm:config ; else command -v llvm-config ; fi"))))
+
+; https://dune.readthedocs.io/en/latest/reference/actions/index.html
 (rule 
- (targets llvmconf.sexp)
- ; use opam if present otherwise fall back to $LLVM_CONFIG
- (action (bash "if command -v opam; then llvm_config=$(opam var conf-llvm:config); fi ; ${llvm_config:-$LLVM_CONFIG} --libs > llvmconf.sexp"))
-)
+ (target llvmconf.sexp)
+ (action (with-stdout-to %{target}
+  (setenv conf "%{read:llvmconf.pth}"
+   (pipe-stdout
+    ; (bash "printf 'llvm-config: %q\n' $conf >&2")
+    (bash "printf -- '-cclib %s\n' $($conf --libs)")
+    (bash "cat ; printf -- '-ccopt %s\n' $($conf --ldflags) $($conf --cflags)")
+    (bash "echo '(' ; cat ; echo ')'"))))))
 


### PR DESCRIPTION
fortunately, it wasn't too hard to make this compatible - just some different phrasing in the dune files. this was tested to build with https://github.com/katrinafyi/pac-nix/pull/3.

along the way, i have also cleaned up slightly the endian handling in the to_asli function. now, there is a distinction between opnum (the opcode as number) and opcode (the code as bytes). as written in a comment, "opnum is the numeric opcode (necessarily BE) and opcode_* are always LE".

while we are making incompatible changes, it would also be nice to restructure the semantics auxdata into a _map\<opcode, semantics\>_. however, this would require more understanding of the protobuf/json wrangling than i have, and i already reached the limit of ocaml i wanted to do for the day. 