### PR TITLE
debug-gts.py: support armv9a, add arguments for chunks and extra llvm-mc args

### DIFF
--- a/scripts/debug-gts.py
+++ b/scripts/debug-gts.py
@@ -216,7 +216,7 @@ def main():
                     default=sys.stdout)
   argp.add_argument('--debug', action='store_true',
                     help='prioritise debugging failing opcodes instead of performance.')
-  argp.add_argument('--args', dest='llvmmc_args', default='-mattr=v9a',
+  argp.add_argument('--args', dest='llvmmc_args', default='-mattr=v9.3a',
                     help='extra arguments to pass to llvm-mc. will be shell split.')
 
   args = argp.parse_args()


### PR DESCRIPTION
addresses #13.

The crash can be investigated with this PR's additional arguments using:
```bash
pipx run scripts/debug-gts.py crash/chase_lev_deque.gts --args='' --debug
```
This tells us the offending opcode is `0x64 0xfc 0xe0 0xc8`, which corresponds to a `casal   x0, x4, [x3]`, which is in v8.1+. I assume llvm-mc defaults to an earlier version of arm64. 

In this PR, I've bumped the default Arm standard to v9a and added a flag to override this if needed. This should be a superset of the standard that aslp supports (v8.6?).

Note to reviewer: I am iffy about the global arguments object. Suggestions are welcome.