### PR TITLE
Major refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ extras/example-bin/example.gts
 extras/example-bin/example.ast
 extras/example-bin/example.ast.json.t
 extras/example-bin/example.ast.json
+
+.venv

--- a/bin/dune
+++ b/bin/dune
@@ -1,4 +1,5 @@
 (executable
  (public_name gtirb_semantics)
  (name main)
+ (flags (:standard -w -69))
  (libraries base64 yojson gtirb_semantics asli.libASL))

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -212,9 +212,9 @@ let () =
     let to_list x = `List x  in
     let jsoned (asts: string list list )  : Yojson.Safe.t = mapmap (fun s -> `String s) asts |> map to_list |> to_list in
     (*let quote bin = strung ^ (Bytes.to_string bin) ^ strung      in *)
-    let paired: Yojson.Safe.t  list = (map (fun l -> `Assoc (map (fun b -> (((Base64.encode_exn (Bytes.to_string  b.auuid))), (jsoned b.asts))) l)) with_asts) in
-      (* List.iter (fun f -> Yojson.Safe.pretty_to_channel stdout f) paired; *)
-      map (Yojson.Safe.to_string) paired
+    let paired: Yojson.Safe.t list = (map (fun l -> `Assoc (map (fun b -> (((Base64.encode_exn (Bytes.to_string  b.auuid))), (jsoned b.asts))) l)) with_asts) in
+    List.iter (fun f -> Yojson.Safe.pretty_to_channel stderr f) paired; 
+    map (Yojson.Safe.to_string) paired
   in 
 
   (* Sandwich ASTs into the IR amongst the other auxdata *)

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -192,12 +192,13 @@ let do_module (m: Module.t): Module.t =
           with_asts) in
     Yojson.Safe.pretty_to_channel stderr paired; 
 
+    let json_str = Yojson.Safe.pretty_to_string paired in
     if !json_file <> "" then begin
       let f = open_out !json_file in
-      Yojson.Safe.pretty_to_channel f paired;
+      output_string f json_str;
       close_out f
     end;
-    Yojson.Safe.to_string paired
+    json_str
   in 
 
   (* Sandwich ASTs into the IR amongst the other auxdata *)

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -129,14 +129,6 @@ let do_module (m: Module.t): Module.t =
     fix_mod op_cuts
   in
 
-  (* hashtable for memoising disassembly results by opcode. *)
-  let tbl : (bytes, string list) Hashtbl.t = Hashtbl.create 10000 in
-  let tbl_update k f =
-    match Hashtbl.find_opt tbl k with
-    | Some x -> x
-    | None -> let x = f () in (Hashtbl.replace tbl k x; x)
-  in
-
   Printexc.record_backtrace true;
   let env =
     match Eval.aarch64_evaluation_environment () with
@@ -168,7 +160,7 @@ let do_module (m: Module.t): Module.t =
           opnum_str opcode_str (Printexc.to_string exc);
         Printexc.print_backtrace stderr;
         exit 1)
-    in tbl_update opcode_be (fun x -> fst @@ do_dis x)
+    in fst @@ do_dis ()
   in
   let rec asts opcodes addr =
     match opcodes with

--- a/dune-project
+++ b/dune-project
@@ -19,7 +19,7 @@
  (name gtirb_semantics)
  (synopsis "Add semantic information to the IR of a disassembled ARM64 binary")
  (description "A longer description")
- (depends ocaml dune Yojson asli ocaml-protoc-plugin base64)
+ (depends ocaml dune yojson asli ocaml-protoc-plugin base64)
  (tags
   (decompilers instruction-lifters static-analysis)))
 

--- a/dune-project
+++ b/dune-project
@@ -19,7 +19,7 @@
  (name gtirb_semantics)
  (synopsis "Add semantic information to the IR of a disassembled ARM64 binary")
  (description "A longer description")
- (depends ocaml dune Yojson asli ocaml-protoc-plugin hexstring base64)
+ (depends ocaml dune Yojson asli ocaml-protoc-plugin base64)
  (tags
   (decompilers instruction-lifters static-analysis)))
 

--- a/gtirb_semantics.opam
+++ b/gtirb_semantics.opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/UQ-PAC/gtirb-semantics/issues"
 depends: [
   "ocaml"
   "dune" {>= "3.6"}
-  "Yojson"
+  "yojson"
   "asli"
   "ocaml-protoc-plugin"
   "base64"

--- a/gtirb_semantics.opam
+++ b/gtirb_semantics.opam
@@ -15,7 +15,6 @@ depends: [
   "Yojson"
   "asli"
   "ocaml-protoc-plugin"
-  "hexstring"
   "base64"
   "odoc" {with-doc}
 ]

--- a/lib/dune
+++ b/lib/dune
@@ -1,6 +1,6 @@
 (library
  (name gtirb_semantics)
- (libraries ocaml-protoc-plugin asli.libASL hexstring base64))
+ (libraries ocaml-protoc-plugin asli.libASL base64))
 
 (rule
  (targets AuxData.ml ByteInterval.ml CFG.ml CodeBlock.ml DataBlock.ml IR.ml Module.ml Offset.ml ProxyBlock.ml Section.ml Symbol.ml SymbolicExpression.ml)


### PR DESCRIPTION
Rewrites the logic into separate functions for handling modules and blocks, instead of use of map map. 

This will conflict badly with existing unmerged branches.