### PR TITLE
`proto-json.py --auxdata`

### DIFF
--- a/scripts/proto-json.py
+++ b/scripts/proto-json.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python3
 # vim: ts=2 sts=2 et sw=2
 
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "gtirb~=2.0.0",
+# ]
+# ///
+
 import google.protobuf.message_factory
 import google.protobuf.descriptor_pool
 import google.protobuf.descriptor_pb2
@@ -14,7 +21,9 @@ import logging
 import pathlib
 import typing
 import base64
+import gtirb
 import shlex
+import uuid
 import json
 import zlib
 import sys
@@ -147,12 +156,48 @@ def main():
     # see: https://github.com/protocolbuffers/protobuf/blob/main/python/google/protobuf/json_format.py
     # and: https://protobuf.dev/programming-guides/proto3/#json
     msgdict = google.protobuf.json_format.MessageToDict(
-      message, 
-      always_print_fields_with_no_presence=True, 
+      message,
+      always_print_fields_with_no_presence=True,
       preserving_proto_field_name=True
     )
 
-    data = json.dumps(msgdict, sort_keys=True, indent=2)
+    if args.proto == _gtirb:
+      ser = gtirb.serialization.Serialization()
+
+      def process_keys(x):
+        if isinstance(x, tuple):
+          return str(tuple(process_keys(y) for y in x))
+        else:
+          return process_auxdata(x)
+
+      def process_auxdata(x):
+        if isinstance(x, list):
+          return [process_auxdata(y) for y in x]
+        elif isinstance(x, dict):
+          if set(x.keys()) == {'type_name', 'data'}:
+            data = base64.b64decode(x['data'])
+            return process_auxdata({
+              'type_name': x['type_name'],
+              '_decoded': ser.decode(data, x['type_name'])
+            })
+          return dict((process_keys(k), process_auxdata(v)) for k,v in x.items())
+        elif isinstance(x, uuid.UUID):
+          return base64.b64encode(x.bytes).decode('ascii')
+        elif isinstance(x, gtirb.offset.Offset):
+          return str(x)
+        elif x is None or isinstance(x, (str, int, float, bool, bytes)):
+          return x
+        elif isinstance(x, tuple):
+          return tuple(process_auxdata(y) for y in x)
+        elif isinstance(x, set):
+          return set(process_auxdata(y) for y in x)
+        else:
+          assert False, "unsup type " + repr(x)
+
+      msgdict = process_auxdata(msgdict)
+      # print(msgdict)
+
+    data = json.dumps(msgdict, indent=2, sort_keys=True, default=str)
     args.output.write(data.encode('utf-8'))
 
 

--- a/scripts/proto-json.py
+++ b/scripts/proto-json.py
@@ -148,7 +148,7 @@ def main():
     # and: https://protobuf.dev/programming-guides/proto3/#json
     msgdict = google.protobuf.json_format.MessageToDict(
       message, 
-      including_default_value_fields=True, 
+      always_print_fields_with_no_presence=True, 
       preserving_proto_field_name=True
     )
 

--- a/scripts/proto-json.py
+++ b/scripts/proto-json.py
@@ -157,7 +157,9 @@ def main():
     # and: https://protobuf.dev/programming-guides/proto3/#json
     msgdict = google.protobuf.json_format.MessageToDict(
       message,
-      always_print_fields_with_no_presence=True,
+including_default_value_fields=True,
+
+      # always_print_fields_with_no_presence=True,
       preserving_proto_field_name=True
     )
 
@@ -171,7 +173,12 @@ def main():
           return process_auxdata(x)
 
       def process_auxdata(x):
-        if isinstance(x, list):
+        if isinstance(x, bytes):
+          try:
+            return json.loads(x.decode('ascii'))
+          except Exception:
+            return str(x)
+        elif isinstance(x, list):
           return [process_auxdata(y) for y in x]
         elif isinstance(x, dict):
           if set(x.keys()) == {'type_name', 'data'}:
@@ -190,7 +197,7 @@ def main():
         elif isinstance(x, tuple):
           return tuple(process_auxdata(y) for y in x)
         elif isinstance(x, set):
-          return set(process_auxdata(y) for y in x)
+          return [process_auxdata(y) for y in x]
         else:
           assert False, "unsup type " + repr(x)
 


### PR DESCRIPTION
proto-json.py has learned the `--auxdata` flag. when specified, the script will try to decode binary AuxData fields into JSON based on the recorded `type_name`. for example:
```json
  "aux_data": {
    "ddisasmVersion": {
      "_decoded": "1.9.0 (UNKNOWN 1980-01-01) ARM64+IA32+X64+ARM32+MIPS32",
      "type_name": "string"
    }
  },
```
this makes it much easier to explore the AuxData fields, especially the more complex ones.

using the --auxdata flag requires the gtirb python library to be installed, since we use it for the auxdata decoder. you can use pipx to run the script and automatically install the dependency:
```
pipx run scripts/proto-json.py
```

also updates in line with breaking changes in profobuf 26: https://protobuf.dev/news/v26/